### PR TITLE
Add configurable log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,11 +952,15 @@ seguinte código.
 
 ```python
 import logging
+import os
 
 from rich.logging import RichHandler
 
+level_name = os.getenv("SUSSU_LOG_LEVEL", "INFO").upper()
+level = getattr(logging, level_name, logging.INFO)
+
 logging.basicConfig(
-    level="CRITICAL",
+    level=level,
     format="%(message)s",
     datefmt="[%H:%M]",
     handlers=[
@@ -972,6 +976,9 @@ logging.basicConfig(
 
 logger = logging.getLogger("rich")
 ```
+
+Defina a variável de ambiente `SUSSU_LOG_LEVEL` para controlar o nível de log.
+Se nenhuma for definida, o padrão será `INFO`.
 
 Agora sim, vamos ver o código. Deixei vários comentário explicando tudo.
 

--- a/src/sussu/basic_logger.py
+++ b/src/sussu/basic_logger.py
@@ -1,9 +1,13 @@
 import logging
+import os
 
 from rich.logging import RichHandler
 
+level_name = os.getenv("SUSSU_LOG_LEVEL", "INFO").upper()
+level = getattr(logging, level_name, logging.INFO)
+
 logging.basicConfig(
-    level="CRITICAL",
+    level=level,
     format="%(message)s",
     datefmt="[%H:%M]",
     handlers=[


### PR DESCRIPTION
## Summary
- make log level configurable via `SUSSU_LOG_LEVEL`
- show how to set log level in README

## Testing
- `PYENV_VERSION=3.11.12 ruff check .`
- `PYENV_VERSION=3.11.12 pyright`

------
https://chatgpt.com/codex/tasks/task_e_685fc7a007f483299d3c96daa8b78484