### PR TITLE
Fix case handling for batch extensions

### DIFF
--- a/src/sussu/cli.py
+++ b/src/sussu/cli.py
@@ -68,7 +68,8 @@ def batch_whisper(
             continue
 
         # Pulamos se a extensão não for permitida
-        if file.suffix not in allowed_extensions:
+        # Normaliza a extensão para evitar problemas de caixa alta
+        if file.suffix.lower() not in allowed_extensions:
             logger.error(f"File extension not allowed: {file.name}")
             continue
 


### PR DESCRIPTION
## Summary
- ensure batch extension check is case-insensitive by normalizing to lowercase
- add brief comment to clarify why

## Testing
- `python3 -m py_compile src/sussu/cli.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_685fc96aec7c83299d695499d105bc1b